### PR TITLE
Fixed issue where you wouldn't get fire tokens from the FoH tavern

### DIFF
--- a/EK Unleashed/GameClient.cs
+++ b/EK Unleashed/GameClient.cs
@@ -199,7 +199,7 @@ namespace EKUnleashed
 
                 for (int i = 0; i < 100; i++)
                 {
-                    JObject lottery_result = JObject.Parse(this.GetGameData("league", "lottery"));
+                    JObject lottery_result = JObject.Parse(this.GetGameData("league", "lottery", "New=1"));
 
                     if (Utils.CInt(lottery_result["status"]) != 1)
                         break;


### PR DESCRIPTION
In the current version of Elemental Kingdoms, an additional parameter is POST'ed to /league.php?do=lottery (New=1) The response still indicates that you get extra rolls, but you will now get the tokens in your reward box.
