### PR TITLE
Updated version to 1.8.0

### DIFF
--- a/EK Unleashed/GameClient.cs
+++ b/EK Unleashed/GameClient.cs
@@ -56,7 +56,7 @@ namespace EKUnleashed
                 return
                     "&phpp=ANDROID_ARC" +
                     "&phpl=EN" +
-                    "&pvc=1.7.5" +
+                    "&pvc=1.8.0" +
                     "&pvb=" + System.Web.HttpUtility.UrlEncode(TAG_EK_DateOnLoad); // for 1.7.5 they switched the date to the current date/time vs the build date/time
             }
         }

--- a/EK Unleashed/frmMain.cs
+++ b/EK Unleashed/frmMain.cs
@@ -724,12 +724,9 @@ namespace EKUnleashed
         {
             return string.Concat(new object[]
 			{
-				"&phpp=", "ANDROID_ARC",
-				"&phpl=", "EN",
-				"&pvc=",  "1.7.5",
+                GameClient.TAG_EK,
 				"&phpk=", frmMain.CalculateMD5SumForGamePacket(),
-				"&phps=", frmMain.AuthSerial,
-				"&pvb=", System.Web.HttpUtility.UrlEncode(GameClient.TAG_EK_DateOnLoad)
+				"&phps=", frmMain.AuthSerial
 			});
         }
 


### PR DESCRIPTION
 This fixes the issue where maze clears would not register for Kingdoms Tower opening progress
